### PR TITLE
Kate - PR27 build error fix

### DIFF
--- a/components/basketball/matches/MatchList.tsx
+++ b/components/basketball/matches/MatchList.tsx
@@ -15,7 +15,7 @@ const MatchList: React.FC<MatchListProps> = ({
 }) => {
   const filterMatches = (
     matches: any[],
-    timeOption: string,
+    timeOption: string = 'all',
     teamOption: string = 'all'
   ) => {
     // Get the current date

--- a/components/basketball/teams/TeamSelector.tsx
+++ b/components/basketball/teams/TeamSelector.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import React from "react";
-import { Listbox, ListboxItem, cn } from "@nextui-org/react";
+import React, { ReactNode } from "react";
+import { Listbox, ListboxItem } from "@nextui-org/react";
 import TeamImage from "./TeamImage";
 import { faPeopleGroup } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -10,7 +10,7 @@ import { useSearchParams, useRouter, usePathname } from "next/navigation";
 interface TeamSelectorProp {
   seasonTeams: BbSeasonTeam[];
   allBtnText?: string;
-  allBtnIcon?: IconDefinition;
+  allBtnIcon?: ReactNode; // ReactNode for JSX elements
 }
 
 export const TeamSelector: React.FC<TeamSelectorProp> = ({


### PR DESCRIPTION
## Pull Request

<!-- Provide a brief summary of the changes introduced by this pull request -->
This PR fixes the error in deployment / build of PR#27.

### Description

<!-- Provide a more detailed description of the changes and the motivation behind them -->

### Related Issue(s)

<!-- If this pull request addresses any existing issues, mention them here -->
PR 27 failed build because of the following errors:
1. in MatchList.tsx, the String component timeOption in line 80 cannot accept String/Undefined as a parameter. 
2. in TeamSelector.tsx, the allBtnIcon is a IconDefinition, which generates `Type 'IconDefinition | Element' is not assignable to type 'ReactNode'. Type 'IconDefinition' is not assignable to type 'ReactNode'.` in the return line. 

Now fixed:
1. give the timeOption a default value as "all".
2. change the allBtnIcon to ReactNode.

### Test


### Additional Notes

<!-- Add any additional notes or comments that may be helpful for the reviewers -->
<img width="1501" alt="Screenshot 2024-08-28 at 14 10 36" src="https://github.com/user-attachments/assets/acb00a4e-c1b6-4db4-9060-76a6f3ee413d">

