### PR TITLE
Match Stat Summary Table

### DIFF
--- a/app/basketball/[competition]/matches/[matchid]/page.tsx
+++ b/app/basketball/[competition]/matches/[matchid]/page.tsx
@@ -206,8 +206,6 @@ export default async function Page({ params, searchParams }: any) {
         }
     }
 
-    console.log(section, teamAscores, teamBscores);
-
     return (
         <div className='matchStat'>
             <MatchSumTable sections={section} teamAname={teamAname} teamBname={teamBname} teamAscores={teamAscores} teamBscores={teamBscores}></MatchSumTable>

--- a/app/basketball/[competition]/matches/[matchid]/page.tsx
+++ b/app/basketball/[competition]/matches/[matchid]/page.tsx
@@ -2,6 +2,44 @@ import Custom404 from '@/components/404';
 import { asyncFetch } from '@/utils/fetch';
 import MatchStatContents from '@/components/basketball/matchStat/MatchStatContents';
 import "../match.css"
+import MatchSumTable from '@/components/basketball/matchStat/MatchSumTable';
+
+function updateSection(record: string | null): number {
+    if (record && record.includes('节 start')) {
+        return 1;
+    }
+    return 0;
+}
+
+function isScore(record: string | null): boolean {
+    return record ? record.includes('Made') : false;
+}
+
+function getScore(record: string | null): number {
+    if (record) {
+        if (record.includes('Two Point Made')) {
+            return 2;
+        } else if (record.includes('Three Point Made')) {
+            return 3;
+        } else if (record.includes('Free Throw Made')) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+function getTeamName(record: string | null): string {
+    if (!record) return '';
+    
+    const start = record.indexOf('[');
+    const end = record.indexOf(']');
+    
+    if (start !== -1 && end !== -1) {
+        return record.substring(start + 1, end);
+    }
+    
+    return '';
+}
 
 export default async function Page({ params, searchParams }: any) {
     // fetch current match data
@@ -25,6 +63,8 @@ export default async function Page({ params, searchParams }: any) {
     var seasonid = match.season.id;
     var teamAid = match.teama.id;
     var teamBid = match.teamb.id;
+    var teamAname = match.teama.name;
+    var teamBname = match.teamb.name;
 
     var teamAdata : BbStat[] = [];
     var teamBdata : BbStat[] = [];
@@ -142,8 +182,35 @@ export default async function Page({ params, searchParams }: any) {
     teamAdata.push(teamAtotal);
     teamBdata.push(teamBtotal);
 
+    var matchLogResponse = await asyncFetch(`/basketball/matchlog?matchid=${params.matchid}&$limit=200`);
+    if (!matchLogResponse) {
+        return (
+            <Custom404 />
+        )
+    }
+
+    var matchLogs:BbMatchLog[] = matchLogResponse.data;
+    var section = -1;
+
+    const teamAscores = [0,0,0,0,0,0];
+    const teamBscores = [0,0,0,0,0,0];
+    for (var log of matchLogs) {
+        section += updateSection(log.event);
+        if (isScore(log.event)) {
+            var teamName = getTeamName(log.event);
+            if (teamName == teamAname) {
+                teamAscores[section] += getScore(log.event);
+            } else if (teamName == teamBname) {
+                teamBscores[section] += getScore(log.event);
+            }
+        }
+    }
+
+    console.log(section, teamAscores, teamBscores);
+
     return (
         <div className='matchStat'>
+            <MatchSumTable sections={section} teamAname={teamAname} teamBname={teamBname} teamAscores={teamAscores} teamBscores={teamBscores}></MatchSumTable>
             <MatchStatContents match={match} teamAdata={teamAdata} teamBdata={teamBdata}></MatchStatContents>
         </div>
     );

--- a/components/basketball/matchStat/MatchStatContents.tsx
+++ b/components/basketball/matchStat/MatchStatContents.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { asyncFetch } from '@/utils/fetch';
 import MatchStatTable from "@/components/basketball/matchStat/MatchStatTable";
 import React from 'react';
 

--- a/components/basketball/matchStat/MatchSumTable.tsx
+++ b/components/basketball/matchStat/MatchSumTable.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { Table, TableBody, TableCell, TableHeader, TableRow } from '@nextui-org/react';
+import React from 'react';
+
+interface MatchSumTableProps {
+    sections: number;
+    teamAname: string;
+    teamBname: string;
+    teamAscores: number[];
+    teamBscores: number[];
+}
+
+const MatchSumTable: React.FC<MatchSumTableProps> = ({sections,teamAname, teamBname, teamAscores, teamBscores}) => {
+    return (
+        <div className="p-5 bg-gray-50 rounded-lg overflow-x-auto">
+          <h1 className="text-2xl font-bold text-gray-800 mt-10 mb-2">Summary</h1>
+          <Table className="w-full border-collapse">
+            <TableHeader>
+              <TableCell className="p-2 border border-gray-300 text-center">队名</TableCell>
+              <TableCell className="p-2 border border-gray-300 text-center">第一节</TableCell>
+              <TableCell className="p-2 border border-gray-300 text-center">第二节</TableCell>
+              <TableCell className="p-2 border border-gray-300 text-center">第三节</TableCell>
+              <TableCell className="p-2 border border-gray-300 text-center">第四节</TableCell>
+              {sections >= 4 ? (
+                <TableCell className="p-2 border border-gray-300 text-center">第一加时</TableCell>
+              ) : (<></>)}
+              {sections >= 5 ? (
+                <TableCell className="p-2 border border-gray-300 text-center">第二加时</TableCell>
+              ) : (<></>)}
+              <TableCell className="p-2 border border-gray-300 text-center font-bold">总分</TableCell>
+            </TableHeader>
+            <TableBody>
+              <TableRow>
+                <TableCell className="p-2 border border-gray-300 text-center">{teamAname}</TableCell>
+                <TableCell className="p-2 border border-gray-300 text-center">{teamAscores[0]}</TableCell>
+                <TableCell className="p-2 border border-gray-300 text-center">{teamAscores[1]}</TableCell>
+                <TableCell className="p-2 border border-gray-300 text-center">{teamAscores[2]}</TableCell>
+                <TableCell className="p-2 border border-gray-300 text-center">{teamAscores[3]}</TableCell>
+                {sections >= 4 ? (
+                    <TableCell className="p-2 border border-gray-300 text-center">{teamAscores[4]}</TableCell>
+                ) : (<></>)}
+                {sections >= 5 ? (
+                    <TableCell className="p-2 border border-gray-300 text-center">{teamAscores[5]}</TableCell>
+                ) : (<></>)}
+                <TableCell className="p-2 border border-gray-300 text-center font-bold">{teamAscores.reduce((acc, score) => acc + score, 0)}</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell className="p-2 border border-gray-300 text-center">{teamBname}</TableCell>
+                <TableCell className="p-2 border border-gray-300 text-center">{teamBscores[0]}</TableCell>
+                <TableCell className="p-2 border border-gray-300 text-center">{teamBscores[1]}</TableCell>
+                <TableCell className="p-2 border border-gray-300 text-center">{teamBscores[2]}</TableCell>
+                <TableCell className="p-2 border border-gray-300 text-center">{teamBscores[3]}</TableCell>
+                {sections >= 4 ? (
+                    <TableCell className="p-2 border border-gray-300 text-center">{teamBscores[4]}</TableCell>
+                ) : (<></>)}
+                {sections >= 5 ? (
+                    <TableCell className="p-2 border border-gray-300 text-center">{teamBscores[5]}</TableCell>
+                ) : (<></>)}
+                <TableCell className="p-2 border border-gray-300 text-center font-bold">{teamBscores.reduce((acc, score) => acc + score, 0)}</TableCell>
+            </TableRow>
+            </TableBody>
+          </Table>
+        </div>
+    );
+}
+
+export default MatchSumTable

--- a/components/basketball/matchStat/MatchSumTable.tsx
+++ b/components/basketball/matchStat/MatchSumTable.tsx
@@ -1,68 +1,108 @@
 "use client";
 
-import { Table, TableBody, TableCell, TableHeader, TableRow } from '@nextui-org/react';
-import React from 'react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableRow,
+  TableColumn,
+} from "@nextui-org/react";
+import React from "react";
 
 interface MatchSumTableProps {
-    sections: number;
-    teamAname: string;
-    teamBname: string;
-    teamAscores: number[];
-    teamBscores: number[];
+  sections: number;
+  teamAname: string;
+  teamBname: string;
+  teamAscores: number[];
+  teamBscores: number[];
 }
 
-const MatchSumTable: React.FC<MatchSumTableProps> = ({sections,teamAname, teamBname, teamAscores, teamBscores}) => {
-    return (
-        <div className="p-5 bg-gray-50 rounded-lg overflow-x-auto">
-          <h1 className="text-2xl font-bold text-gray-800 mt-10 mb-2">Summary</h1>
-          <Table className="w-full border-collapse">
-            <TableHeader>
-              <TableCell className="p-2 border border-gray-300 text-center">队名</TableCell>
-              <TableCell className="p-2 border border-gray-300 text-center">第一节</TableCell>
-              <TableCell className="p-2 border border-gray-300 text-center">第二节</TableCell>
-              <TableCell className="p-2 border border-gray-300 text-center">第三节</TableCell>
-              <TableCell className="p-2 border border-gray-300 text-center">第四节</TableCell>
-              {sections >= 4 ? (
-                <TableCell className="p-2 border border-gray-300 text-center">第一加时</TableCell>
-              ) : (<></>)}
-              {sections >= 5 ? (
-                <TableCell className="p-2 border border-gray-300 text-center">第二加时</TableCell>
-              ) : (<></>)}
-              <TableCell className="p-2 border border-gray-300 text-center font-bold">总分</TableCell>
-            </TableHeader>
-            <TableBody>
-              <TableRow>
-                <TableCell className="p-2 border border-gray-300 text-center">{teamAname}</TableCell>
-                <TableCell className="p-2 border border-gray-300 text-center">{teamAscores[0]}</TableCell>
-                <TableCell className="p-2 border border-gray-300 text-center">{teamAscores[1]}</TableCell>
-                <TableCell className="p-2 border border-gray-300 text-center">{teamAscores[2]}</TableCell>
-                <TableCell className="p-2 border border-gray-300 text-center">{teamAscores[3]}</TableCell>
-                {sections >= 4 ? (
-                    <TableCell className="p-2 border border-gray-300 text-center">{teamAscores[4]}</TableCell>
-                ) : (<></>)}
-                {sections >= 5 ? (
-                    <TableCell className="p-2 border border-gray-300 text-center">{teamAscores[5]}</TableCell>
-                ) : (<></>)}
-                <TableCell className="p-2 border border-gray-300 text-center font-bold">{teamAscores.reduce((acc, score) => acc + score, 0)}</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell className="p-2 border border-gray-300 text-center">{teamBname}</TableCell>
-                <TableCell className="p-2 border border-gray-300 text-center">{teamBscores[0]}</TableCell>
-                <TableCell className="p-2 border border-gray-300 text-center">{teamBscores[1]}</TableCell>
-                <TableCell className="p-2 border border-gray-300 text-center">{teamBscores[2]}</TableCell>
-                <TableCell className="p-2 border border-gray-300 text-center">{teamBscores[3]}</TableCell>
-                {sections >= 4 ? (
-                    <TableCell className="p-2 border border-gray-300 text-center">{teamBscores[4]}</TableCell>
-                ) : (<></>)}
-                {sections >= 5 ? (
-                    <TableCell className="p-2 border border-gray-300 text-center">{teamBscores[5]}</TableCell>
-                ) : (<></>)}
-                <TableCell className="p-2 border border-gray-300 text-center font-bold">{teamBscores.reduce((acc, score) => acc + score, 0)}</TableCell>
-            </TableRow>
-            </TableBody>
-          </Table>
-        </div>
-    );
+function formatStatsDataForTable(
+  sections: number,
+  teamAname: string,
+  teamBname: string,
+  teamAscores: number[],
+  teamBscores: number[]
+) {
+  const columns = ["队名", "第一节", "第二节", "第三节", "第四节"];
+  const dataTeamA = [teamAname, ...teamAscores.slice(0, 4)];
+  const dataTeamB = [teamBname, ...teamBscores.slice(0, 4)];
+  if (sections >= 4) {
+    columns.push("第一加时");
+    dataTeamA.push(teamAscores[4]);
+    dataTeamB.push(teamBscores[4]);
+  }
+  if (sections >= 5) {
+    columns.push("第二加时");
+    dataTeamA.push(teamAscores[5]);
+    dataTeamB.push(teamBscores[5]);
+  }
+  columns.push("总分");
+  dataTeamA.push(teamAscores.reduce((acc, score) => acc + score, 0));
+  dataTeamB.push(teamBscores.reduce((acc, score) => acc + score, 0));
+
+  return {
+    columns,
+    dataTeamA,
+    dataTeamB,
+  };
 }
 
-export default MatchSumTable
+const MatchSumTable: React.FC<MatchSumTableProps> = ({
+  sections,
+  teamAname,
+  teamBname,
+  teamAscores,
+  teamBscores,
+}) => {
+  const { columns, dataTeamA, dataTeamB } = formatStatsDataForTable(
+    sections,
+    teamAname,
+    teamBname,
+    teamAscores,
+    teamBscores
+  );
+  return (
+    <div className="p-5 bg-gray-50 rounded-lg overflow-x-auto">
+      <h1 className="text-2xl font-bold text-gray-800 mt-10 mb-2">Summary</h1>
+
+      <Table className="w-full border-collapse">
+        <TableHeader>
+          {columns.map((col) => (
+            <TableColumn
+              key={col}
+              className="p-2 border border-gray-300 text-center"
+            >
+              {col}
+            </TableColumn>
+          ))}
+        </TableHeader>
+        <TableBody>
+          <TableRow>
+            {dataTeamA.map((cell, idx) => (
+              <TableCell
+                key={`teamA_${idx}`}
+                className="p-2 border border-gray-300 text-center"
+              >
+                {cell}
+              </TableCell>
+            ))}
+          </TableRow>
+          <TableRow>
+            {dataTeamB.map((cell, idx) => (
+              <TableCell
+                key={`teamA_${idx}`}
+                className="p-2 border border-gray-300 text-center"
+              >
+                {cell}
+              </TableCell>
+            ))}
+          </TableRow>
+        </TableBody>
+      </Table>
+    </div>
+  );
+};
+
+export default MatchSumTable;

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/schema/basketball/stat.d.ts
+++ b/schema/basketball/stat.d.ts
@@ -21,3 +21,11 @@ type BbStat = {
     shot: number;
     player: BbPlayer;
 }
+
+type BbMatchLog = {
+    logid: number;
+    matchid: number;
+    playerid: number;
+    event: string;
+    teamid: number;
+}


### PR DESCRIPTION
## Pull Request

<!-- Provide a brief summary of the changes introduced by this pull request -->
This PR adds a match stat quarter summary table. 

### Description

<!-- Provide a more detailed description of the changes and the motivation behind them -->
Quarter summary for both teams on match stat page. Can be accessed by path `/basketball/[competition]/matches/[matchid]`

![Screenshot 2024-09-09 at 09 04 47](https://github.com/user-attachments/assets/d74ae4f8-af57-492a-8e36-05b3891c9379)

### Related Issue(s)

<!-- If this pull request addresses any existing issues, mention them here -->

### Test


### Additional Notes

<!-- Add any additional notes or comments that may be helpful for the reviewers -->